### PR TITLE
Get rid of `DialogContent` requires a `DialogTitle` error

### DIFF
--- a/src/components/admin-panel/sheet-menu.tsx
+++ b/src/components/admin-panel/sheet-menu.tsx
@@ -8,6 +8,7 @@ import {
   SheetHeader,
   SheetContent,
   SheetTrigger,
+  SheetTitle
 } from "@/components/ui/sheet";
 
 export function SheetMenu() {
@@ -27,7 +28,7 @@ export function SheetMenu() {
           >
             <Link href="/dashboard" className="flex items-center gap-2">
               <PanelsTopLeft className="w-6 h-6 mr-1" />
-              <h1 className="font-bold text-lg">Brand</h1>
+              <SheetTitle className="font-bold text-lg">Brand</SheetTitle>
             </Link>
           </Button>
         </SheetHeader>


### PR DESCRIPTION
I've had this "`DialogContent` requires a `DialogTitle`" error. I've replaced the h1 with the Sheet Title, which is basicaly the Dialog Title of the radix dialog.

![image](https://github.com/user-attachments/assets/7fb1befc-9bed-48a1-86c0-9157c4689423)
 
There are no changes to the UI: 
```typescript
              <SheetTitle className="font-bold text-lg">Brand</SheetTitle>
              <h1 className="font-bold text-lg">Brand</h1>
```

looks like this: 

![image](https://github.com/user-attachments/assets/44b8c81d-318a-4c95-956b-f221d7c76576)

